### PR TITLE
Ensure all empty parentheses are removed in all cases (e.g. '()')

### DIFF
--- a/documentation/create_overview_doc/createdoc.sh
+++ b/documentation/create_overview_doc/createdoc.sh
@@ -267,8 +267,8 @@ function fix_mermaid_syntax() {
     local mermaid_content="$1"
     local fixed_mermaid_content
 
-    # Remove empty parentheses '()' often incorrectly included by AI
-    fixed_mermaid_content=$(echo "$mermaid_content" | sed 's/\.\?()//g')
+    # Ensure all empty parentheses are removed in all cases (e.g. '()')
+    fixed_mermaid_content=$(echo "$mermaid_content" | sed 's/()//g')
 
     # Remove all double quotations '"' which can cause syntax errors
     fixed_mermaid_content=$(echo "$fixed_mermaid_content" | sed 's/"//g')


### PR DESCRIPTION
Any empty pair of parenthesis causes a syntax error in mermaid and this is commonly an error when AI make Mermaid Scripts for function calls, and we are now correctly parsing it out.

I have done countless testing to ensure that we can safely remove "()" without any loss to the Mermaid Script and syntax errors improvements will continue to improve as I run across common syntax errors to manually handle.